### PR TITLE
Fix build script on MacOS

### DIFF
--- a/UnixConsoleEcho.build.ps1
+++ b/UnixConsoleEcho.build.ps1
@@ -41,7 +41,7 @@ task BuildNative {
     }
 
     # If not Windows or Linux then assume MacOS
-    g++ -dynamiclib -o $PSScriptRoot/src/Native/Unix/build/libdisablekeyecho.dylib $PSScriptRoot/src/Native/Unix/disable_key_echo.cpp
+    g++ -dynamiclib -o $PSScriptRoot/src/Native/Unix/build/libdisablekeyecho.dylib $PSScriptRoot/src/Native/Unix/disable_key_echo.cpp -std=c++0x
 }
 
 task DoPack {


### PR DESCRIPTION
This change fixes an issue where the build script would fail on MacOS
with an error referencing the `nullptr` keyword.  Thank you @tylerl0706!

Fixes #1 