### PR TITLE
use common values for min and time

### DIFF
--- a/src/UnixConsoleEcho/InputEcho.cs
+++ b/src/UnixConsoleEcho/InputEcho.cs
@@ -25,7 +25,7 @@ namespace UnixConsoleEcho
                 return;
             }
 
-            InitializeConsoleBeforeRead(0, 10);
+            InitializeConsoleBeforeRead();
         }
 
         /// <summary>


### PR DESCRIPTION
Leaving them to default values enabled ssh and sudo prompts to work again.

NOTE: There is still an issue once the ssh session is started with `-echo` but that's a separate issue.